### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -3,7 +3,7 @@
  * - Generate a new log entry
 **/
 
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 var Log = function( options ){
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -4,7 +4,7 @@
 **/
 
 // Dependencies
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 // Class
 var Store = function( options ){

--- a/package.json
+++ b/package.json
@@ -1,29 +1,40 @@
 {
-	"name": "apptrack",
-	"description": "Application tracking for the client and the server",
-	"version": "0.6.5",
-	"author": "makesites",
-	"contributors": [
-		{ "name": "Makis Tracend", "url": "http://github.com/tracend" }
-	],
-	"keywords": ["open", "web", "analytics", "free", "service"],
-	"repository": "git://github.com/makesites/apptrack.git",
-	"license": "Apache-2.0",
-	"licenses": [
-		{
-			"type": "Apache license, version 2.0",
-			"url": "http://makesites.org/licenses/APACHE-2.0"
-		}
-	],
-	"engines": { "node": ">=0.8.x" },
-	"main": "index",
-	"scripts": {
-		"test": "make test"
-	},
-	"dependencies": {
-		"async": "~0.9.0",
-		"connect": "~3.3.4",
-		"node-uuid": "~1.4.2",
-		"underscore": "1.8.3"
-	}
+  "name": "apptrack",
+  "description": "Application tracking for the client and the server",
+  "version": "0.6.5",
+  "author": "makesites",
+  "contributors": [
+    {
+      "name": "Makis Tracend",
+      "url": "http://github.com/tracend"
+    }
+  ],
+  "keywords": [
+    "open",
+    "web",
+    "analytics",
+    "free",
+    "service"
+  ],
+  "repository": "git://github.com/makesites/apptrack.git",
+  "license": "Apache-2.0",
+  "licenses": [
+    {
+      "type": "Apache license, version 2.0",
+      "url": "http://makesites.org/licenses/APACHE-2.0"
+    }
+  ],
+  "engines": {
+    "node": ">=0.8.x"
+  },
+  "main": "index",
+  "scripts": {
+    "test": "make test"
+  },
+  "dependencies": {
+    "async": "~0.9.0",
+    "connect": "~3.3.4",
+    "underscore": "1.8.3",
+    "uuid": "^3.0.0"
+  }
 }

--- a/stores/simpledb.js
+++ b/stores/simpledb.js
@@ -3,7 +3,7 @@
  * - Saving data using SimpleDB
 **/
 
-//var uuid = require("node-uuid"),
+//var uuid = require("uuid"),
 var _ = require("underscore");
 
 var CRUD = function( options ){


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.